### PR TITLE
#7 resolved

### DIFF
--- a/server/main.go
+++ b/server/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"io/ioutil"
+	"log"
 	"net/http"
 	"os"
 	"strconv"
@@ -61,7 +62,19 @@ func main() {
 
 	sessionLock = new(sync.Mutex)
 
-	http.ListenAndServe(servingAddress, nil)
+	certPath := os.Getenv("ROLLD_SERVER_CERTPATH")
+	if certPath == "" {
+		panic("enviornment variable ROLLD_SERVER_CERTPATH must be set")
+	}
+	keyPath := os.Getenv("ROLLD_SERVER_KEYPATH")
+	if keyPath == "" {
+		panic("enviornment variable ROLLD_SERVER_KEYPATH must be set")
+	}
+
+	httpErr := http.ListenAndServeTLS(servingAddress, certPath, keyPath, nil)
+	if httpErr != nil {
+		log.Fatalf("error starting web server: %v\n", httpErr)
+	}
 }
 
 // Initiate a new rolld session. Returns a SessionID that must be included

--- a/server/rolld-client.html
+++ b/server/rolld-client.html
@@ -358,7 +358,7 @@
                         sessionToken = $("#sessionid").val().trim();
                     }
                     
-                    let wsAddr = "ws://" + location.host + "/messages/" + sessionToken + "/" + connectionToken;
+                    let wsAddr = "wss://" + location.host + "/messages/" + sessionToken + "/" + connectionToken;
                     messageSocket = new WebSocket(wsAddr);
                     messageSocket.onopen = messageSocketConnected;
                     messageSocket.onmessage = messageSocketMessage;


### PR DESCRIPTION
Switched from unsecured HTTP  to HTTPS.

Added code to load cery and key file paths from the environment.

Client code merely switched from ws: to wss:. That is all. And it just works.