### PR TITLE
#36 resolved.

### DIFF
--- a/server/main.go
+++ b/server/main.go
@@ -45,7 +45,7 @@ func main() {
 	if dbFilename == "" {
 		panic("environment variable ROLLD_DATABASE_FILE must be set")
 	}
-	db := manageddb.NewManagedDB(dbFilename, "sqlite3")
+	db := manageddb.NewManagedDB(dbFilename, "sqlite3", databaseMigrations)
 	model = models.NewModel(db)
 
 	r := mux.NewRouter()

--- a/server/migrations.go
+++ b/server/migrations.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"database/sql"
+
+	"github.com/adamcrossland/rolld/manageddb"
+)
+
+var databaseMigrations map[int]manageddb.DBMigration
+
+func init() {
+	databaseMigrations = map[int]manageddb.DBMigration{
+		1: manageddb.DBMigration{Up: migration1up, Down: migration1down},
+		2: manageddb.DBMigration{Up: migration2up, Down: migration2down},
+	}
+}
+
+func migration1up(db *sql.DB) error {
+	_, err := db.Exec("create table db_metadata (migration integer); insert into db_metadata (migration) values (0)")
+
+	return err
+}
+
+func migration1down(db *sql.DB) error {
+	_, err := db.Exec("drop table db_metadata")
+
+	return err
+}
+
+func migration2up(db *sql.DB) error {
+	_, err := db.Exec(`create table sessions (id text primary key, connections integer, created integer);
+	create table connections (id text primary key, session text, name text, created integer)`)
+
+	return err
+}
+
+func migration2down(db *sql.DB) error {
+	_, err := db.Exec("drop table sessions")
+
+	return err
+}


### PR DESCRIPTION
The db migrations are now provided to the database initializer function as
a parameter, and the apps specific migrations are now part of the
main package.

There's no difference to the end-user, but this makes the code much neater
and more modular.